### PR TITLE
chore(ENG-11425): replace semantic-release PAT with GitHub App tokens

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -22,8 +22,6 @@ jobs:
         steps:
             - name: Checkout Repo
               uses: actions/checkout@v4
-              with:
-                  token: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
 
             - name: Use Node ${{ matrix.node }}
               uses: actions/setup-node@v4
@@ -53,17 +51,25 @@ jobs:
 
     create-pre-release:
         runs-on: ubuntu-latest
+        environment: TAG
         needs:
             - build-release
         strategy:
             matrix:
                 node: ["20.x"]
         steps:
+            - name: Mint tag-app token
+              id: tag-token
+              uses: actions/create-github-app-token@v3
+              with:
+                  app-id: ${{ vars.GH_TAG_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_TAG_KEY }}
+
             - name: Version and Tag
               id: version-and-tag
               uses: mathieudutour/github-tag-action@v5.2
               with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  github_token: ${{ steps.tag-token.outputs.token }}
 
             - name: Generate Release Notes
               id: release-notes
@@ -94,7 +100,7 @@ jobs:
                   body: ${{ steps.release-notes.outputs.result }}
                   tag_name: ${{ steps.version-and-tag.outputs.new_tag }}
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ steps.tag-token.outputs.token }}
 
             - name: Stop Deploy Message
               if: always()

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -21,22 +21,22 @@ jobs:
             HUSKY: 0 # disables husky hooks
         steps:
             - name: Checkout Repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Use Node ${{ matrix.node }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version: ${{ matrix.node }}
                   # registry-url not needed - no npm publishing in dev workflow
 
             - name: Install Deps (with cache)
-              uses: bahmutov/npm-install@v1
+              uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
               with:
                   install-command: yarn --immutable --no-progress --ignore-scripts
 
             - name: Get New Version
               id: get-new-version
-              uses: mathieudutour/github-tag-action@v5.2
+              uses: mathieudutour/github-tag-action@a2505118dd9b4797d9f8d45747f562db67e2aa6c # v5.2
               with:
                   dry_run: true
                   github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -60,20 +60,20 @@ jobs:
         steps:
             - name: Mint tag-app token
               id: tag-token
-              uses: actions/create-github-app-token@v3
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
               with:
                   app-id: ${{ vars.GH_TAG_APP_ID }}
                   private-key: ${{ secrets.GH_APP_TAG_KEY }}
 
             - name: Version and Tag
               id: version-and-tag
-              uses: mathieudutour/github-tag-action@v5.2
+              uses: mathieudutour/github-tag-action@a2505118dd9b4797d9f8d45747f562db67e2aa6c # v5.2
               with:
                   github_token: ${{ steps.tag-token.outputs.token }}
 
             - name: Generate Release Notes
               id: release-notes
-              uses: actions/github-script@v6
+              uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
               env:
                   NEW_RELEASE_TAG: ${{ steps.version-and-tag.outputs.new_tag }}
               with:
@@ -93,7 +93,7 @@ jobs:
                       return releaseNotes.data.body;
 
             - name: Create Pre-Release
-              uses: softprops/action-gh-release@v1
+              uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
               with:
                   prerelease: true
                   generate_release_notes: false
@@ -104,7 +104,7 @@ jobs:
 
             - name: Stop Deploy Message
               if: always()
-              uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+              uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
               with:
                   slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
                   channel: ${{ vars.SLACK_DUCKBOT_DEV_DEPLOY_CHANNEL_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,25 +21,25 @@ jobs:
     steps:
       - name: Mint semantic-release app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
           private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Start Deploy Message
-        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
           # registry-url is intentionally NOT set - it creates .npmrc that blocks OIDC
@@ -95,7 +95,7 @@ jobs:
 
       - name: Stop Deploy Message
         if: always()
-        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,17 @@ jobs:
     env:
       CI: 1
     steps:
+      - name: Mint semantic-release app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Start Deploy Message


### PR DESCRIPTION
## Description
- `deploy-dev.yml` — cut the tag/pre-release with the **bt-version-tagger** app: mint a token via `actions/create-github-app-token` (`vars.GH_TAG_APP_ID` + `secrets.GH_APP_TAG_KEY`) in the `TAG` environment (master-restricted) and pass it to `github-tag-action` + `softprops`. Drop the PAT from checkout.
- `release.yml` — mint a **bt_semantic_release** token (`vars.SEMANTIC_RELEASE_APP_ID` + the `prod`-env `secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY`) and use it for checkout + the `git push origin HEAD:master` write-back. npm OIDC publish stays on the native token.
- Removes all `GH_SEMANTIC_RELEASE_PAT` usage. Public repo, so no private composite action is referenced (inlined `create-github-app-token`).

> Merge order: requires github-repository-management#441 (prod write-back key + new TAG env for this repo) applied first, and the bt-version-tagger + bt_semantic_release apps installed on this repo.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
ENG-11425

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change