### PR TITLE
fix(ENG-11681): pin npm to 11.18.0 for Node 20 compatibility in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           # registry-url is intentionally NOT set - it creates .npmrc that blocks OIDC
 
       - name: Update npm for Trusted Publishing
-        run: npm install -g npm@latest # Requires npm 11.5.1+ for OIDC support
+        run: npm install -g npm@11.18.0 # Pinned: npm 11.5.1+ needed for OIDC, Node 20 compatible (npm 12+ requires Node 22+)
 
       - name: Install deps
         run: yarn --immutable --no-progress --ignore-scripts


### PR DESCRIPTION
Linear: [ENG-11681](https://linear.app/basis-theory/issue/ENG-11681)

## Description
- The release job's **Update npm for Trusted Publishing** step ran `npm install -g npm@latest`, which now resolves to `npm@12.0.1`. npm 12+ requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, but the release matrix pins Node `20.x`, so the step failed with `EBADENGINE` and the **v4.0.0 release did not publish**.
- Pin to `npm@11.18.0` — the latest npm 11.x, which supports Node 20 and still satisfies the npm 11.5.1+ requirement for OIDC trusted publishing. Matches the pin used in other Basis Theory release workflows.

## Business Impact
Unblocks npm publishing for `react-native-elements` releases (v4.0.0 and forward). No runtime/consumer impact — CI-only change.

## Testing
- Verified failure root cause from the failed run: `npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}` / `Actual: {"npm":"10.8.2","node":"v20.20.2"}`.
- `npm@11.18.0` is Node-20 compatible (`engines.node: ^20.17.0 || >=22.9.0`) and >= 11.5.1, so OIDC trusted publishing still works.
- Full verification is the next release run publishing successfully.

## Screenshots
N/A — workflow config change.

## Rollback
Revert this commit. The prior `npm@latest` line returns (and the release step resumes failing on Node 20).

## Documentation
N/A

## Reviewer Checklist
- [ ] Change is limited to the release workflow's npm install step
- [ ] Pinned version supports Node 20 and OIDC trusted publishing (>= 11.5.1)