### PR TITLE
chore(release): 4.0.1 [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           # registry-url is intentionally NOT set - it creates .npmrc that blocks OIDC
 
       - name: Update npm for Trusted Publishing
-        run: npm install -g npm@latest # Requires npm 11.5.1+ for OIDC support
+        run: npm install -g npm@11.18.0 # Pinned: npm 11.5.1+ needed for OIDC, Node 20 compatible (npm 12+ requires Node 22+)
 
       - name: Install deps
         run: yarn --immutable --no-progress --ignore-scripts
@@ -69,7 +69,14 @@ jobs:
             echo "CHANGELOG already lists ${VER}; skipping."
             exit 0
           fi
+          # The release tag already exists (it triggered this run); drop it
+          # locally so conventional-changelog emits this version instead of an
+          # empty section. The remote tag is untouched.
+          git tag -d "$TAG_NAME" 2>/dev/null || true
           yarn changelog:release
+          if ! grep -qF "[$VER](" CHANGELOG.md; then
+            echo "::warning::conventional-changelog produced no ${VER} entry (no conventional commits since the previous tag)."
+          fi
 
       - name: Build
         run: make build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,69 @@
 
+## [4.0.1](https://github.com/Basis-Theory/react-native-elements/compare/v3.0.1...v4.0.1) (2026-07-22)
+
+
+### Features
+
+* upgrade react native ([#51](https://github.com/Basis-Theory/react-native-elements/issues/51))
+* bump release ([#52](https://github.com/Basis-Theory/react-native-elements/issues/52))
+
+
+### Bug Fixes
+
+* pin npm to 11.18.0 for Node 20 compatibility in release ([#53](https://github.com/Basis-Theory/react-native-elements/issues/53))
+
+
+### Chores
+
+* replace semantic-release PAT with GitHub App tokens ([#50](https://github.com/Basis-Theory/react-native-elements/issues/50))
+
+
+### BREAKING CHANGES
+
+* upgrade react native ([#51](https://github.com/Basis-Theory/react-native-elements/issues/51))
+
+## [3.0.1](https://github.com/Basis-Theory/react-native-elements/compare/v3.0.0...v3.0.1) (2026-06-09)
+
+
+### Chores
+
+* remove debug log for requestInit ([#48](https://github.com/Basis-Theory/react-native-elements/issues/48))
+
+# [3.0.0](https://github.com/Basis-Theory/react-native-elements/compare/v2.5.3...v3.0.0) (2026-06-03)
+
+
+### Features
+
+* support additional networks, implement preSelectedNetworks ([#46](https://github.com/Basis-Theory/react-native-elements/issues/46))
+* bump version for breaking change release ([#47](https://github.com/Basis-Theory/react-native-elements/issues/47))
+
+
+### Chores
+
+* add AGENTS.md with developer essentials ([#44](https://github.com/Basis-Theory/react-native-elements/issues/44))
+
+
+### BREAKING CHANGES
+
+* support additional networks, implement preSelectedNetworks ([#46](https://github.com/Basis-Theory/react-native-elements/issues/46))
+
+## [2.5.3](https://github.com/Basis-Theory/react-native-elements/compare/v2.5.1...v2.5.3) (2026-04-16)
+
+
+### Features
+
+* remove token intent delete method from sdk ([#43](https://github.com/Basis-Theory/react-native-elements/issues/43))
+
+
+### Chores
+
+* update changelog and changelog generation ([#45](https://github.com/Basis-Theory/react-native-elements/issues/45))
+
+
+### BREAKING CHANGES
+
+* remove token intent delete method from sdk ([#43](https://github.com/Basis-Theory/react-native-elements/issues/43))
+
 ## [2.5.1](https://github.com/Basis-Theory/react-native-elements/compare/v2.5.0...v2.5.1) (2026-01-27)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basis-theory/react-native-elements",
-  "version": "3.0.1",
+  "version": "4.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/Basis-Theory/react-native-elements"


### PR DESCRIPTION
## Summary

`master` had drifted out of sync with npm: `4.0.1` is published as `latest`, but `package.json` was still at `3.0.1` and `CHANGELOG.md` topped out at `2.5.1`. This backfills the missing published releases, bumps the version to match npm, and fixes the release workflow step that was silently producing empty changelog entries.

## Changes

- Bumped `package.json` from `3.0.1` to `4.0.1` to match the current npm `latest`.
- Backfilled `CHANGELOG.md` with the releases that were actually published to npm — `2.5.3`, `3.0.0`, `3.0.1`, and `4.0.1`. Tags `2.5.2`, `3.0.2`, `3.0.3`, and `4.0.0` were never published, so their commits (#50, #51, #52) roll forward into the `4.0.1` entry; compare links reference only consecutive published tags.
- Fixed the `Update CHANGELOG` step in `release.yml` so future releases generate real entries instead of empty ones, and added a `::warning::` when a release yields no entry.